### PR TITLE
Add consensus sequence FASTA files to MultiQC HTML report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.1 - [2020-11-06]
+
+Patch release to make MultiQC reports a bit more useful with consensus sequence FASTA files embedded for download.
+
+### `Added`
+
+- Consensus sequence FASTA files are embedded within the MultiQC HTML report and can be downloaded from it.
+
 ## v1.0.0 - [2020-10-25]
 
-WIP: First release of peterk87/nf-ionampliseq workflow.
+First release of peterk87/nf-ionampliseq workflow.
 
 ### `Added`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you wish to use custom names and a specific AmpliSeq panel it is recommended 
 10. [Consensus Sequence](docs/output.md#consensus-sequence) - Majority consensus sequence with `N` masking of low/no coverage positions.
 11. [Edlib Pairwise Alignment](docs/output.md#edlib-pairwise-alignment) - Pairwise global alignment and edit distance between reference and consensus sequences.
 12. [Coverage Plots](#coverage-plots) - Coverage plots with/without low/no coverage and/or variants highlighted with linear and log10 scaling of y-axis depth values.
-13. [MultiQC](docs/output.md#multiqc) - Aggregate report describing results from the whole pipeline
+13. [MultiQC](docs/output.md#multiqc) - Aggregate report describing results from the whole pipeline. Consensus sequences are embedded in the MultiQC HTML report and can be downloaded from it.
 14. [Pipeline information](docs/output.md#pipeline-information) - Report metrics generated during the workflow execution
 
 ### Output

--- a/bin/consensus_fasta_multiqc.py
+++ b/bin/consensus_fasta_multiqc.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import base64
+from pathlib import Path
+
+import click
+
+
+header = '''
+<!--
+id: 'consensus-fasta'
+section_name: 'Consensus sequence FASTA files'
+description: 'This section contains the consensus sequences FASTA files for each sample.'
+-->
+
+<ul>
+'''
+
+footer = '''
+</ul>
+'''
+
+def to_html_li(fasta: str) -> str:
+    fasta_path = Path(fasta)
+    b64 = base64.encodebytes(fasta_path.read_bytes())
+    return f'''
+    <li>
+    <a
+      download="{fasta_path.name}"
+      href="data:text/plain;base64,{b64.decode()}">
+        Download {fasta_path.name}
+    </a>
+    </li>
+    '''
+
+
+@click.command()
+@click.argument('input_fasta', type=click.Path(exists=True), nargs=-1)
+@click.argument('output_html', type=click.Path(exists=False), nargs=1)
+def main(input_fasta, output_html):
+    """Embed FASTA file content into HTML for inclusion in MultiQC report"""
+    with open(output_html, 'w') as fout:
+        fout.write(header)
+        for fasta in input_fasta:
+            fout.write(to_html_li(fasta))
+        fout.write(footer)
+
+if __name__ == '__main__':
+    main()

--- a/docs/output.md
+++ b/docs/output.md
@@ -193,6 +193,8 @@ For more information about how to use MultiQC reports, see [https://multiqc.info
   * `multiqc_data/`: directory containing parsed statistics from the different tools used in the pipeline.
   * `multiqc_plots/`: directory containing static images from the report in various formats.
 
+> **NB:** All consensus sequence FASTA files will be embedded within the MultiQC HTML report and can be downloaded from it.
+
 ## Pipeline information
 
 [Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.

--- a/main.nf
+++ b/main.nf
@@ -118,7 +118,7 @@ include { SAMTOOLS_DEPTH; SAMTOOLS_STATS } from './modules/processes/samtools'
 include { TVC } from './modules/processes/tvc'
 include { BCFTOOLS_VCF_FILTER; BCFTOOLS_VCF_NORM; BCFTOOLS_STATS } from './modules/processes/bcftools'
 include { MOSDEPTH_GENOME } from './modules/processes/mosdepth'
-include { CONSENSUS } from './modules/processes/consensus'
+include { CONSENSUS; CONSENSUS_MULTIQC } from './modules/processes/consensus'
 include { COVERAGE_PLOT } from './modules/processes/plotting'
 include { EDLIB_ALIGN; EDLIB_MULTIQC } from './modules/processes/edlib'
 
@@ -232,6 +232,7 @@ workflow {
   BCFTOOLS_VCF_FILTER.out | BCFTOOLS_STATS
 
   CONSENSUS.out | map { [ it[0], it[4], it[2] ]} | EDLIB_ALIGN
+  CONSENSUS.out | map { [ it[4] ] } | collect | CONSENSUS_MULTIQC
 
   EDLIB_ALIGN.out.json | collect | EDLIB_MULTIQC
 
@@ -271,6 +272,7 @@ workflow {
     MASH_SCREEN_MULTIQC_SUMMARY.out.collect(),
     BCFTOOLS_STATS.out.collect().ifEmpty([]),
     EDLIB_MULTIQC.out.collect().ifEmpty([]),
+    CONSENSUS_MULTIQC.out.collect().ifEmpty([]),
     SOFTWARE_VERSIONS.out.software_versions_yaml.collect(),
     ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")
   )

--- a/modules/processes/consensus.nf
+++ b/modules/processes/consensus.nf
@@ -31,3 +31,16 @@ process CONSENSUS {
     --sample-name $sample
   """
 }
+
+process CONSENSUS_MULTIQC {
+  input:
+  path(fastas)
+
+  output:
+  path('consensus_mqc.html')
+
+  script:
+  """
+  consensus_fasta_multiqc.py $fastas consensus_mqc.html
+  """
+}

--- a/modules/processes/multiqc.nf
+++ b/modules/processes/multiqc.nf
@@ -10,6 +10,7 @@ process MULTIQC {
   path('mash_screen/*')
   path('bcftools/*')
   path('edlib/*')
+  path('consensus/*')
   path('software_versions/*')
   path(workflow_summary)
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -133,7 +133,7 @@ manifest {
   description = 'Ion Torrent Ampliseq workflow for analysis of FMDV, CSFV, Zika, Ebola amplicon sequence data'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.04.0'
-  version = '1.0.0'
+  version = '1.0.1'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
This PR adds consensus sequence FASTA files to the MultiQC HTML report as custom HTML. It's expected that the FASTA files will be only a few KB each so they shouldn't add too much to the HTML size. 

## PR checklist

- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.md` is updated
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Documentation in `docs` is updated
